### PR TITLE
Updated Pagelist so that it allows the user to decide which instance to return

### DIFF
--- a/web/concrete/src/Page/PageList.php
+++ b/web/concrete/src/Page/PageList.php
@@ -175,12 +175,21 @@ class PageList extends DatabaseItemList implements PermissionableListItemInterfa
     }
 
     /**
+     * The class that will be returned by the getResult function
+     * @return string
+     */
+    public function getPageClass()
+    {
+        return '\\Concrete\\Core\\Page\\Page';
+    }
+
+    /**
      * @param $queryRow
      * @return \Concrete\Core\File\File
      */
     public function getResult($queryRow)
     {
-        $c = ConcretePage::getByID($queryRow['cID'], 'ACTIVE');
+        $c = ConcretePage::getByID($queryRow['cID'], 'ACTIVE', $this->getPageClass());
         if (is_object($c) && $this->checkPermissions($c)) {
             if ($this->pageVersionToRetrieve == self::PAGE_VERSION_RECENT) {
                 $cp = new \Permissions($c);


### PR DESCRIPTION
This allows to define your own model to return in the PageList.

Users can define their own Page Model to be return by their own PageList Repository.

Example:

``` php
// application/src/Models/car.php

namespace Application\Src\Models;

use Concrete\Core\Page\Page as ConcretePage;
use Concrete\Core\User\User;
use Exception;

class Car extends ConcretePage {

    public function isPurchasedByCurrentUser() {
        if( !User::isLoggedIn() ) {
            return false;
        }
        $user = new User();
        $user->getUserID();

        return $this->isPurchasedBy( $user );
    }

    public function isPurchasedBy( $user ) {
        throw new Exception( 'Implement relationship with user and bought cars' );
    }

}

```

``` php
// application/src/Repositories/cars.php

namespace Application\Src\Repositories;

use Application\Src\Models\Car;
use Concrete\Core\Page\PageList;
use Concrete\Core\Search\StickyRequest;

class CarsRepository extends PageList {

    public function __construct( StickyRequest $req = null ) {
        parent::__construct( $req );
        $this->filterByPageTypeHandle( 'car' );
    }

    public function getPageClass() {
        return '\\Application\\Src\\Models\\Car';
    }

}

```

Could it be useful?

The performances might be slower, since the Page::getById uses a cache key based on the class to return.
Nonetheless, I think it could be cool :D

Thank you!

// (saving for later)
